### PR TITLE
Assign JAVA_HOME_IN to JAVA_HOME

### DIFF
--- a/SecureTomcatJDBC.sh
+++ b/SecureTomcatJDBC.sh
@@ -51,6 +51,7 @@ else
 	echo -e "\n Trying to Obtain JAVA_HOME during runtime"
 	echo "Enter the JAVA_HOME:"
 	read JAVA_HOME_IN
+	JAVA_HOME=$JAVA_HOME_IN
 	if [ -e $JAVA_HOME_IN/bin/javac -a -e $JAVA_HOME_IN/bin/java -a -e $JAVA_HOME_IN/bin/jar ]
 	then
 		echo "INFO: Java Home Validation Successful - RUNTIME. Good to Go"


### PR DESCRIPTION
When JAVA_HOME is not found in line 44, JAVA_HOME_IN is provided but never assigned to JAVA_HOME that will be used later on the code.