### PR TITLE
First JAR is corrupted

### DIFF
--- a/SecureTomcatJDBC.sh
+++ b/SecureTomcatJDBC.sh
@@ -113,7 +113,7 @@ else
 fi
 
 echo "INFO: Creating a Jar file SecureTomcatJDBC.jar"
-$JAVA_HOME/bin/jar -cvfM SecureTomcatJDBC.jar *.class META-INF
+$JAVA_HOME/bin/jar -cvfe SecureTomcatJDBC.jar EncDecJDBCPass *.class
 
 if [ $? -ne 0 -o ! -e SecureTomcatJDBC.jar ]
 then


### PR DESCRIPTION
The first JAR you try to generate it says is corrupted because MANIFEST.MF is not inside META-INF under the JAR generated. This will fix it, declare the MainClass and change the JAR tags to -cvfe.